### PR TITLE
Google map에서 사용하지 않는 버튼 제거

### DIFF
--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -3,7 +3,9 @@ import PropTypes from "prop-types";
 
 const MAP_OPTION = {
   zoom: 15,
-  center: { lat: 37.6347813, lng: 127.0793528 }
+  center: { lat: 37.6347813, lng: 127.0793528 },
+  zoomControl: false,
+  mapTypeControl: false
 };
 
 const Map = props => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22635168/78812646-b39c9f80-7a06-11ea-896a-310f0d3cde83.png)

좌측 상단과 우측하단 사용하지 않는 google map default ui 제거